### PR TITLE
use left-grouping behavior of read-cdot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+compiled/
+doc/
+*~

--- a/remix/tests/reader.rkt
+++ b/remix/tests/reader.rkt
@@ -55,10 +55,10 @@
    ["a . b" (#%dot a b)]
    ["1.a" (#%dot 1 a)]
    ["#i1.2 .a" (#%dot 1.2 a)]
-   ["1 .2.a" (#%dot 1 (#%dot 2 a))]
+   ["1 .2.a" (#%dot (#%dot 1 2) a)]
    ["a.#i1.2" (#%dot a 1.2)]
    ;; ((sprite.bbox).ul).x
-   ["a.b.c" (#%dot a (#%dot b c))]
+   ["a.b.c" (#%dot (#%dot a b) c)]
    ["a.(b c)" (#%dot a (b c))]
    ["(a b).c" (#%dot (a b) c)]
    ["(a b).(c d)" (#%dot (a b) (c d))]


### PR DESCRIPTION
Goes with pull request https://github.com/racket/racket/pull/1446 on the Racket repository.

Instead of flattening `(#%dot dt x ... (#%dot . y))` into `(#%dot dt x ... . y)`, the new `#%dot` macro flattens `(#%dot (#%dot dt x) . y)` into `(#%dot dt x . y)`.
