### PR TITLE
enable line counting on new input port

### DIFF
--- a/remix/stx/raw0.rkt
+++ b/remix/stx/raw0.rkt
@@ -50,8 +50,9 @@
   (define (get-location)
     (values line col pos))
 
-  (make-input-port name read-in #f void #f #f
-                   get-location void #f #f))
+  (parameterize ([port-count-lines-enabled #t])
+    (make-input-port name read-in #f void #f #f
+                     get-location void #f #f)))
 
 (provide
  (contract-out


### PR DESCRIPTION
Because the underlying #lang probably assumes it's enabled